### PR TITLE
fixes bug in verbose printing of empty train dataset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ForestForesight
 Type: Package
 Title: Package created to preprocess, model, predict and analyze deforestation according to the WWF-NL ForestForesight principles.
-Version: 4.3.3
-Date: 2025-11-04
+Version: 4.3.4
+Date: 2026-03-25
 Authors@R: 
   c(person(given = "Jonas", 
            family = "van Duijvenbode", 

--- a/R/ff_run.R
+++ b/R/ff_run.R
@@ -520,7 +520,7 @@ prepare_training_data <- function(ff_folder, shape, train_dates, filter_conditio
   ff_prep_params_combined <- merge_lists(ff_prep_params_original, ff_prep_parameters)
 
   train_input_data <- do.call(ff_prep, ff_prep_params_combined)
-  if(sum(ff_prep$feature_dataset$label)==0){
+  if(sum(train_input_data$feature_dataset$label)==0){
     ff_cat("after data loading and filtering no actuals (Positives)
            have been found in the input dataset to train on. Either change the area
            , date range or filtering",


### PR DESCRIPTION
This pull request fixes the bug introduced in 4.3.3 when I made the error handling of an empty dataset more verbose. This fixes bug #136 